### PR TITLE
Install LLDP flows whenever a handshake is completed

### DIFF
--- a/main.py
+++ b/main.py
@@ -98,7 +98,7 @@ class Main(KytosNApp):
                               ethernet.source, ethernet.destination,
                               switch.dpid, interface.port_number)
 
-    @listen_to('kytos/core.switch.new')
+    @listen_to('kytos/of_core.handshake.completed')
     def install_lldp_flow(self, event):
         """Install a flow to send LLDP packets to the controller.
 


### PR DESCRIPTION
It turns out LLDP flows were not being reinstalled when switches rebooted for example, since the original event was `kytos/core.swiitch.new`, which only triggers for new switch connections (reconnection are missed). So, I've changed to listen to `kytos/of_core.handshake.completed`. As a result, whenever a handshake is completed the flows will be pushed. 