### PR TITLE
User can now set LLDP polling time by REST API #29

### DIFF
--- a/main.py
+++ b/main.py
@@ -378,14 +378,17 @@ class Main(KytosNApp):
         """Get LLDP polling time."""
         return jsonify({"Polling time in seconds": self.polling_time}), 200
 
-    @rest('v1/time/<time_sec>', methods=['POST'])
-    def set_time(self, time_sec):
+    @rest('v1/polling_time', methods=['POST'])
+    def set_time(self):
         """Set LLDP polling time."""
         # pylint: disable=attribute-defined-outside-init
-
         try:
-            self.polling_time = int(time_sec)
+            payload = request.get_json()
+            self.polling_time = int(payload['polling_time'])
             self.execute_as_loop(self.polling_time)
+            log.info("Polling time has been updated,"
+                     "but this change will not be saved permanently.")
             return jsonify("Polling time has been updated."), 200
-        except ValueError:
-            return jsonify("Bad format."), 400
+        except (ValueError, KeyError) as error:
+            msg = f"This operation is not completed: {error}"
+            return jsonify(msg), 400

--- a/main.py
+++ b/main.py
@@ -373,7 +373,7 @@ class Main(KytosNApp):
         return jsonify({msg_error:
                         error_list}), 400
 
-    @rest('v1/time', methods=['GET'])
+    @rest('v1/polling_time', methods=['GET'])
     def get_time(self):
         """Get LLDP polling time."""
         return jsonify({"Polling time in seconds": self.polling_time}), 200

--- a/main.py
+++ b/main.py
@@ -27,9 +27,10 @@ class Main(KytosNApp):
     def setup(self):
         """Make this NApp run in a loop."""
         self.vlan_id = None
+        self.polling_time = settings.POLLING_TIME
         if hasattr(settings, "FLOW_VLAN_VID"):
             self.vlan_id = settings.FLOW_VLAN_VID
-        self.execute_as_loop(settings.POLLING_TIME)
+        self.execute_as_loop(self.polling_time)
 
     def execute(self):
         """Send LLDP Packets every 'POLLING_TIME' seconds to all switches."""
@@ -371,3 +372,20 @@ class Main(KytosNApp):
         msg_error = "Some interfaces couldn't be found and activated: "
         return jsonify({msg_error:
                         error_list}), 400
+
+    @rest('v1/time', methods=['GET'])
+    def get_time(self):
+        """Get LLDP polling time."""
+        return jsonify({"Polling time in seconds": self.polling_time}), 200
+
+    @rest('v1/time/<time_sec>', methods=['POST'])
+    def set_time(self, time_sec):
+        """Set LLDP polling time."""
+        # pylint: disable=attribute-defined-outside-init
+
+        try:
+            self.polling_time = int(time_sec)
+            self.execute_as_loop(self.polling_time)
+            return jsonify("Polling time has been updated."), 200
+        except ValueError:
+            return jsonify("Bad format."), 400

--- a/main.py
+++ b/main.py
@@ -375,8 +375,8 @@ class Main(KytosNApp):
 
     @rest('v1/polling_time', methods=['GET'])
     def get_time(self):
-        """Get LLDP polling time."""
-        return jsonify({"Polling time in seconds": self.polling_time}), 200
+        """Get LLDP polling time in seconds."""
+        return jsonify({"polling_time": self.polling_time}), 200
 
     @rest('v1/polling_time', methods=['POST'])
     def set_time(self):

--- a/main.py
+++ b/main.py
@@ -384,10 +384,11 @@ class Main(KytosNApp):
         # pylint: disable=attribute-defined-outside-init
         try:
             payload = request.get_json()
-            self.polling_time = int(payload['polling_time'])
+            self.polling_time = abs(int(payload['polling_time']))
             self.execute_as_loop(self.polling_time)
-            log.info("Polling time has been updated,"
-                     "but this change will not be saved permanently.")
+            log.info("Polling time has been updated to %s"
+                     " second(s), but this change will not be saved"
+                     " permanently.", self.polling_time)
             return jsonify("Polling time has been updated."), 200
         except (ValueError, KeyError) as error:
             msg = f"This operation is not completed: {error}"

--- a/openapi.yml
+++ b/openapi.yml
@@ -89,7 +89,7 @@ paths:
               application/json:
                 schema:
                   $ref: '#/components/schemas/Lista'
-                example: {"Polling time in seconds": 3}
+                example: {"polling_time": 3}
 
     post:
       summary: Set the LLDP polling time.

--- a/openapi.yml
+++ b/openapi.yml
@@ -75,6 +75,45 @@ paths:
                 $ref: '#/components/schemas/Lista'
         '400':
           description: Some interfaces have not been disabled.
+
+  /v1/time/:
+    get:
+      summary: Get LLDP Polling time.
+      description: Get LLDP Polling time in seconds.
+      operationId: time_lldp
+      
+      responses:
+          '200':
+            description: OK
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/Lista'
+                example: {"Polling time in seconds": 3}
+
+  /v1/time/{time_sec}:
+    post:
+      summary: Set the LLDP polling time.
+      description: Update LLDP polling time.
+      operationId: set_time_lldp
+      parameters:
+        - name: time_sec
+          in: path
+          required: true
+          schema:
+            type: string
+            example:  5
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Lista'
+              example: 'Polling time has been updated.'
+        '400':
+          description: Bad format.
+
 components:
   schemas:
     Lista:

--- a/openapi.yml
+++ b/openapi.yml
@@ -76,10 +76,10 @@ paths:
         '400':
           description: Some interfaces have not been disabled.
 
-  /v1/time/:
+  /v1/polling_time:
     get:
       summary: Get LLDP Polling time.
-      description: Get LLDP Polling time in seconds.
+      description: Get LLDP polling time in seconds.
       operationId: time_lldp
       
       responses:
@@ -91,18 +91,20 @@ paths:
                   $ref: '#/components/schemas/Lista'
                 example: {"Polling time in seconds": 3}
 
-  /v1/time/{time_sec}:
     post:
       summary: Set the LLDP polling time.
       description: Update LLDP polling time.
-      operationId: set_time_lldp
-      parameters:
-        - name: time_sec
-          in: path
-          required: true
-          schema:
-            type: string
-            example:  5
+      operationId: update_polling_time
+      requestBody:
+        description: Update polling time
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Lista'
+            example:
+                # Properties of a referenced object
+                {"polling_time":4}
       responses:
         '200':
           description: OK

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -342,3 +342,29 @@ class TestMain(TestCase):
 
         self.assertEqual(disable_response.status_code, 400)
         self.assertEqual(enable_response.status_code, 400)
+
+    def test_get_time(self):
+        """Test get polling time."""
+        api = get_test_client(self.napp.controller, self.napp)
+
+        url = f'{self.server_name_url}/v1/polling_time'
+        response = api.open(url, method='GET')
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_set_time(self):
+        """Test update polling time."""
+        data = {"polling_time": 5}
+
+        api = get_test_client(self.napp.controller, self.napp)
+
+        url = f'{self.server_name_url}/v1/polling_time'
+        response = api.open(url, method='POST', json=data)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(self.napp.polling_time, data['polling_time'])
+
+        # test fail
+        data['polling_time'] = 'A'
+        response = api.open(url, method='POST', json=data)
+        self.assertEqual(response.status_code, 400)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -364,7 +364,12 @@ class TestMain(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(self.napp.polling_time, data['polling_time'])
 
-        # test fail
-        data['polling_time'] = 'A'
+    def test_set_time_400(self):
+        """Test fail case the update polling time."""
+        api = get_test_client(self.napp.controller, self.napp)
+
+        url = f'{self.server_name_url}/v1/polling_time'
+
+        data = {'polling_time': 'A'}
         response = api.open(url, method='POST', json=data)
         self.assertEqual(response.status_code, 400)


### PR DESCRIPTION
Today, the user cannot set the LLDP `POLLING_TIME` at run time. This new feature adds a REST terminal, allowing the user change this time. But this modification is not persistent, if NApp restarts, the time set in the `settings.py` file will be loaded and used.

Main Changes:
- Add a REST endpoint that allows the user to update `POLLING_TIME` at the run time.
- Add some uni tests.

Issue fix #33 

Related the discuss about etcd -  [EP020](https://github.com/kytos/kytos/blob/master/docs/blueprints/EP020.rst)