### PR TITLE
Change known_first_party values in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ add-ignore = D105
 
 [isort]
 # The first party was necessary to fix travis build.
-known_first_party = kytos.napps,tests
+known_first_party = kytos.core,tests
 known_third_party = pyof
 # Ignoring tests because is adding napps path
 skip=tests


### PR DESCRIPTION
A lint error was raised calling that imports are unsorted, this commit fixes this problem, changing known_first_party napps value to core in setup.cfg.