### PR TITLE
Added persistence to LLDP changes

### DIFF
--- a/main.py
+++ b/main.py
@@ -183,9 +183,13 @@ class Main(KytosNApp):
                                             'interface_b': interface_b})
             self.controller.buffers.app.put(event_out)
 
-    def notify_lldp_change(self):
-        """Dispatch a KytosEvents to notify changes to the LLDP status."""
-        event_out = KytosEvent(name='kytos/of_lldp.network_status.updated')
+    def notify_lldp_change(self, state, interface_ids):
+        """Dispatch a KytosEvent to notify changes to the LLDP status."""
+        content = {'attribute': 'LLDP',
+                   'state': state,
+                   'interface_ids': interface_ids}
+        event_out = KytosEvent(name='kytos/of_lldp.network_status.updated',
+                               content=content)
         self.controller.buffers.app.put(event_out)
 
     def shutdown(self):
@@ -329,6 +333,7 @@ class Main(KytosNApp):
     def disable_lldp(self):
         """Disables an interface to receive LLDP packets."""
         interface_ids = self._get_data(request)
+        changed_interfaces = interface_ids
         error_list = []  # List of interfaces that were not activated.
         interface_ids = filter(None, interface_ids)
         interfaces = self._get_interfaces()
@@ -342,7 +347,8 @@ class Main(KytosNApp):
             else:
                 error_list.append(id_)
         if not error_list:
-            self.notify_lldp_change()
+
+            self.notify_lldp_change('disabled', changed_interfaces)
             return jsonify(
                 "All the requested interfaces have been disabled."), 200
 
@@ -355,6 +361,7 @@ class Main(KytosNApp):
     def enable_lldp(self):
         """Enable an interface to receive LLDP packets."""
         interface_ids = self._get_data(request)
+        changed_interfaces = interface_ids
         error_list = []  # List of interfaces that were not activated.
         interface_ids = filter(None, interface_ids)
         interfaces = self._get_interfaces()
@@ -368,7 +375,7 @@ class Main(KytosNApp):
             else:
                 error_list.append(id_)
         if not error_list:
-            self.notify_lldp_change()
+            self.notify_lldp_change('enabled', changed_interfaces)
             return jsonify(
                 "All the requested interfaces have been enabled."), 200
 

--- a/main.py
+++ b/main.py
@@ -333,8 +333,8 @@ class Main(KytosNApp):
     def disable_lldp(self):
         """Disables an interface to receive LLDP packets."""
         interface_ids = self._get_data(request)
-        changed_interfaces = interface_ids
         error_list = []  # List of interfaces that were not activated.
+        changed_interfaces = []
         interface_ids = filter(None, interface_ids)
         interfaces = self._get_interfaces()
         if not interfaces:
@@ -344,11 +344,12 @@ class Main(KytosNApp):
             interface = interfaces.get(id_)
             if interface:
                 interface.lldp = False
+                changed_interfaces.append(id_)
             else:
                 error_list.append(id_)
-        if not error_list:
-
+        if changed_interfaces:
             self.notify_lldp_change('disabled', changed_interfaces)
+        if not error_list:
             return jsonify(
                 "All the requested interfaces have been disabled."), 200
 
@@ -361,8 +362,8 @@ class Main(KytosNApp):
     def enable_lldp(self):
         """Enable an interface to receive LLDP packets."""
         interface_ids = self._get_data(request)
-        changed_interfaces = interface_ids
         error_list = []  # List of interfaces that were not activated.
+        changed_interfaces = []
         interface_ids = filter(None, interface_ids)
         interfaces = self._get_interfaces()
         if not interfaces:
@@ -372,10 +373,12 @@ class Main(KytosNApp):
             interface = interfaces.get(id_)
             if interface:
                 interface.lldp = True
+                changed_interfaces.append(id_)
             else:
                 error_list.append(id_)
-        if not error_list:
+        if changed_interfaces:
             self.notify_lldp_change('enabled', changed_interfaces)
+        if not error_list:
             return jsonify(
                 "All the requested interfaces have been enabled."), 200
 

--- a/main.py
+++ b/main.py
@@ -185,7 +185,7 @@ class Main(KytosNApp):
 
     def notify_lldp_change(self):
         """Dispatch a KytosEvents to notify changes to the LLDP status."""
-        event_out = KytosEvent(name='kytos/topology.network_status.updated')
+        event_out = KytosEvent(name='kytos/of_lldp.network_status.updated')
         self.controller.buffers.app.put(event_out)
 
     def shutdown(self):

--- a/main.py
+++ b/main.py
@@ -183,6 +183,11 @@ class Main(KytosNApp):
                                             'interface_b': interface_b})
             self.controller.buffers.app.put(event_out)
 
+    def notify_lldp_change(self):
+        """Dispatch a KytosEvents to notify changes to the LLDP status."""
+        event_out = KytosEvent(name='kytos/topology.network_status.updated')
+        self.controller.buffers.app.put(event_out)
+
     def shutdown(self):
         """End of the application."""
         log.debug('Shutting down...')
@@ -337,6 +342,7 @@ class Main(KytosNApp):
             else:
                 error_list.append(id_)
         if not error_list:
+            self.notify_lldp_change()
             return jsonify(
                 "All the requested interfaces have been disabled."), 200
 
@@ -362,6 +368,7 @@ class Main(KytosNApp):
             else:
                 error_list.append(id_)
         if not error_list:
+            self.notify_lldp_change()
             return jsonify(
                 "All the requested interfaces have been enabled."), 200
 


### PR DESCRIPTION
Now, the LLDP status changes is stored in the NApp storehouse.

Main Improvements:

- Add an event indicating administrative changes to the LLDP.



Related:
- Issue Fix #49 
- PR in topology  https://github.com/kytos/topology/pull/111