### PR TITLE
The polling_time update now accepts only positive numbers

### DIFF
--- a/main.py
+++ b/main.py
@@ -401,7 +401,10 @@ class Main(KytosNApp):
         # pylint: disable=attribute-defined-outside-init
         try:
             payload = request.get_json()
-            self.polling_time = abs(int(payload['polling_time']))
+            polling_time = int(payload['polling_time'])
+            if polling_time <= 0:
+                raise ValueError
+            self.polling_time = polling_time
             self.execute_as_loop(self.polling_time)
             log.info("Polling time has been updated to %s"
                      " second(s), but this change will not be saved"

--- a/main.py
+++ b/main.py
@@ -403,7 +403,8 @@ class Main(KytosNApp):
             payload = request.get_json()
             polling_time = int(payload['polling_time'])
             if polling_time <= 0:
-                raise ValueError
+                raise ValueError(f"invalid polling_time {polling_time}, "
+                                 "must be greater than zero")
             self.polling_time = polling_time
             self.execute_as_loop(self.polling_time)
             log.info("Polling time has been updated to %s"


### PR DESCRIPTION
The polling_time update now accepts only positive numbers greater than 0. This modification prevents the LLDP polling time from being set incorrectly.