### PR TITLE
Update the `polling_time` documentation

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -24,8 +24,8 @@ paths:
                 example:           # Child of media type because we use $ref above
                   # Properties of a referenced object
                   interfaces: ["00:00:00:00:00:00:00:04:65534","00:00:00:00:00:00:00:03:65534"]
-  
-  
+
+
   /v1/interfaces/enable/:
     post:
       summary: Enable interfaces to receive lldp packet.
@@ -50,7 +50,7 @@ paths:
                   $ref: '#/components/schemas/Lista'
           '400':
             description: No interfaces were found.
-  
+
   /v1/interfaces/disable/:
     post:
       summary: Disable Interfaces
@@ -81,7 +81,7 @@ paths:
       summary: Get LLDP Polling time.
       description: Get LLDP polling time in seconds.
       operationId: time_lldp
-      
+
       responses:
           '200':
             description: OK
@@ -92,11 +92,11 @@ paths:
                 example: {"polling_time": 3}
 
     post:
-      summary: Set the LLDP polling time.
-      description: Update LLDP polling time.
+      summary: Update the LLDP polling time at runtime.
+      description: Update LLDP polling time at runtime, this change is not persistent.
       operationId: update_polling_time
       requestBody:
-        description: Update polling time
+        description: The new LLDP polling time in seconds.
         required: true
         content:
           application/json:
@@ -125,4 +125,3 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Lista'
-   


### PR DESCRIPTION
# Pull Request Template

### :octocat: Are you working on some issue? Identify the issue!
Fix #63 

### :bookmark_tabs: Description of the Change

Update the description of `polling_time` endpoint in the API documentation,
making it explicit that the change made at runtime through the
REST endpoint `\polling_time` is not persistent.

### :computer: Verification Process

- Tested in swagger editor.

### :page_facing_up: Release Notes

- Update the ``polling_time``  API documentation 
